### PR TITLE
Update crosslink styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -105,12 +105,19 @@ ul.list-group > li.list-group-item.gray > span.badge > img {
 }
 
 /*
- * low-distraction links
+ * low-distraction
  */
-a.low-distraction {
-  color: #ddd;
+.low-distraction {
   font-size: .8em;
+}
+
+.low-distraction, a.low-distraction, a.low-distraction:active {
+  color: #bbb;
   text-decoration: none;
+}
+
+a.low-distraction:hover {
+  color: #666;
 }
 
 /*

--- a/index.html
+++ b/index.html
@@ -15,7 +15,12 @@
       <div class="col-md-12">
         <div class="page-header">
           <h1>What's in Standard?</h1>
-          <a href="http://standardhearth.com/">(are you looking for what's in Hearthstone Standard?)</a>
+          <div>
+            <span class="low-distraction">for</span>
+            <span>Magic: The Gathering</span>
+            <span class="low-distraction"> / </span>
+            <a href="http://standardhearth.com/" class="low-distraction">Hearthstone</a>
+          </div>
         </div>
       </div>
       <div class="col-md-5">

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
       <div class="col-md-12">
         <div class="page-header">
           <h1>What's in Standard?</h1>
+          <a href="http://standardhearth.com/">(are you looking for what's in Hearthstone Standard?)</a>
         </div>
       </div>
       <div class="col-md-5">


### PR DESCRIPTION
Applies the styling discussed in glacials/whatsinstandard#24.

<img width="400" alt="screenshot 2016-04-16 08 01 24" src="https://cloud.githubusercontent.com/assets/438911/14581747/6fb97b94-03a9-11e6-968e-7a1eda017bec.png">
